### PR TITLE
Feature/particle system

### DIFF
--- a/Week11_1/Engine/Source/Runtime/Core/Container/Array.h
+++ b/Week11_1/Engine/Source/Runtime/Core/Container/Array.h
@@ -75,6 +75,8 @@ public:
 	/** 특정 위치에 있는 요소를 제거합니다. */
     void RemoveAt(SizeType Index);
 
+    void RemoveAtSwap(SizeType Index);
+
 	/** Predicate에 부합하는 모든 요소를 제거합니다. */
     template <typename Predicate>
         requires std::is_invocable_r_v<bool, Predicate, const T&>
@@ -336,6 +338,21 @@ void TArray<T, Allocator>::RemoveAt(SizeType Index)
     if (Index >= 0 && static_cast<SizeType>(Index) < ContainerPrivate.size())
     {
         ContainerPrivate.erase(ContainerPrivate.begin() + Index);
+    }
+}
+
+template <typename T, typename AllocatorType>
+void TArray<T, AllocatorType>::RemoveAtSwap(SizeType Index)
+{
+    SizeType CurrentSize = ContainerPrivate.size();
+    if (Index < CurrentSize)
+    {
+        SizeType LastIndex = CurrentSize - 1;
+        if (Index != LastIndex)
+        {
+            std::swap(ContainerPrivate[Index], ContainerPrivate[LastIndex]);
+        }
+        ContainerPrivate.pop_back();
     }
 }
 

--- a/Week11_1/Engine/Source/Runtime/Engine/Classes/Components/ActorComponent.cpp
+++ b/Week11_1/Engine/Source/Runtime/Engine/Classes/Components/ActorComponent.cpp
@@ -6,6 +6,7 @@
 UActorComponent::UActorComponent()
     : ComponentID(FGuid::NewGuid())
 {
+    bTickInEditor = false;
 }
 
 

--- a/Week11_1/Engine/Source/Runtime/Engine/Classes/Components/ActorComponent.h
+++ b/Week11_1/Engine/Source/Runtime/Engine/Classes/Components/ActorComponent.h
@@ -67,8 +67,8 @@ public:
     void Activate() { bIsActive = true; }
     virtual void Deactivate() { bIsActive = false; }
 
-    bool IsComponentTickEnabled() const { return bTickEnabled; }
-    void SetComponentTickEnabled(const bool bEnabled) { bTickEnabled = bEnabled; }
+    virtual bool IsComponentTickEnabled() const { return bTickEnabled; }
+    virtual void SetComponentTickEnabled(const bool bEnabled) { bTickEnabled = bEnabled; }
 
 public:
     /** Tick을 아예 지원하는 컴포넌트인지 확인합니다. */
@@ -100,6 +100,9 @@ protected:
     
     /** Tick을 지원하는 컴포넌트인지 여부 */
     uint8 bCanEverTick : 1 = 0;
+    
+    /** Should this component be ticked in the editor */
+    uint8 bTickInEditor : 1;
 
     /** 컴포넌트가 Actor에 정상적으로 등록되었는지 여부 */
     uint8 bRegistered : 1 = 0;

--- a/Week11_1/Engine/Source/Runtime/Engine/Classes/Components/PrimitiveComponents/ParticleSystemComponent.h
+++ b/Week11_1/Engine/Source/Runtime/Engine/Classes/Components/PrimitiveComponents/ParticleSystemComponent.h
@@ -445,6 +445,9 @@ public:
     */
     float EmitterDelay;
 
+    /** Scales DeltaTime in UParticleSystemComponent::Tick(...) */
+    float CustomTimeDilation;
+
     /** 이 PSysComp에서 발생한 Spawn 이벤트들입니다. */
     TArray<struct FParticleEventSpawnData> SpawnEvents;
 
@@ -503,6 +506,9 @@ private:
 public:
     virtual void TickComponent(float DeltaTime) override;
 
+    void ComputeTickComponent_Concurrent();
+    void FinalizeTickComponent();
+
 protected:
     virtual bool ShouldActivate() const;
 public:
@@ -514,6 +520,8 @@ public:
     void Deactivate() override;
     void Complete();
     virtual void DeactivateImmediate();
+
+    void ForceReset();
 
     /** Activate the system */
     virtual void ActivateSystem(bool bFlagAsJustAttached = false);

--- a/Week11_1/Engine/Source/Runtime/Engine/Classes/Components/PrimitiveComponents/ParticleSystemComponent.h
+++ b/Week11_1/Engine/Source/Runtime/Engine/Classes/Components/PrimitiveComponents/ParticleSystemComponent.h
@@ -1,7 +1,7 @@
 #pragma once
+#include "PrimitiveComponent.h"
 #include "Container/Array.h"
 #include "Particles/ParticleSystem.h"
-#include "PrimitiveComponent.h"
 #include "Container/EnumAsByte.h"
 
 enum EParticleSysParamType : int
@@ -274,13 +274,14 @@ struct FParticleEventKismetData : public FParticleEventData
 };
 
 
-class  UParticleSystemComponent : public UPrimitiveComponent
+class UParticleSystemComponent : public UPrimitiveComponent
 {
     friend class FParticleSystemWorldManager;
     
     DECLARE_CLASS(UParticleSystemComponent, UPrimitiveComponent)
 public:
     UParticleSystemComponent();
+    ~UParticleSystemComponent() override;
     
     TArray<struct FParticleEmitterInstance*> EmitterInstances;
     UParticleSystem* Template;
@@ -386,6 +387,8 @@ private:
     int32 bPendingManagerRemove : 1;
     
 public:
+    virtual bool Editor_CanBeTickManaged()const { return true; }
+    bool ShouldBeTickManaged()const;
 
     FORCEINLINE bool IsTickManaged()const { return ManagerHandle != INDEX_NONE && !IsPendingManagerRemove(); }
     FORCEINLINE int32 GetManagerHandle()const { return ManagerHandle; }

--- a/Week11_1/Engine/Source/Runtime/Engine/Classes/Engine/World.cpp
+++ b/Week11_1/Engine/Source/Runtime/Engine/Classes/Engine/World.cpp
@@ -23,6 +23,7 @@
 #include "Components/PrimitiveComponents/Physics/UBoxShapeComponent.h"
 #include "GameFramework//PlayerController.h"
 #include "GameFramework/Character.h"
+#include "Particles/ParticleSystemWorldManager.h"
 #include "Script/LuaManager.h"
 #include "UObject/UObjectArray.h"
 #include "UnrealEd/PrimitiveBatch.h"
@@ -43,6 +44,8 @@ void UWorld::InitWorld()
     {
         CreateBaseObject(WorldType);
     }
+
+    FParticleSystemWorldManager::OnWorldInit(this);
 }
 
 void UWorld::LoadLevel(const FString& LevelName)
@@ -106,10 +109,15 @@ void UWorld::Tick(ELevelTick tickType, float deltaSeconds)
 
         FGameManager::Get().Tick(deltaSeconds);
     }
+
+    
+    FParticleSystemWorldManager::Get(this)->Tick(deltaSeconds, tickType);
 }
 
 void UWorld::Release()
 {
+    FParticleSystemWorldManager::OnWorldCleanup(this);
+    
     if (WorldType == EWorldType::Editor)
     {
         SaveScene("Assets/Scenes/AutoSave.Scene");
@@ -131,8 +139,6 @@ void UWorld::Release()
 
 	pickingGizmo = nullptr;
 	ReleaseBaseObject();
-
-    
 }
 
 void UWorld::ClearScene()

--- a/Week11_1/Engine/Source/Runtime/Engine/Classes/Engine/World.cpp
+++ b/Week11_1/Engine/Source/Runtime/Engine/Classes/Engine/World.cpp
@@ -1,6 +1,5 @@
 #include "World.h"
 
-#include "LaunchEngineLoop.h"
 #include "Renderer/Renderer.h"
 #include "PlayerCameraManager.h"
 #include "BaseGizmos/TransformGizmo.h"
@@ -14,22 +13,18 @@
 #include "Contents/GameManager.h"
 #include "Serialization/FWindowsBinHelper.h"
 
-#include "Actors/PointLightActor.h"
-#include "Components/LightComponents/PointLightComponent.h"
-#include "Components/Mesh/StaticMesh.h"
-#include "Components/PrimitiveComponents/MeshComponents/SkeletalMeshComponent.h"
-#include "Components/PrimitiveComponents/MeshComponents/StaticMeshComponents/SkySphereComponent.h"
-#include "Components/PrimitiveComponents/MeshComponents/StaticMeshComponents/StaticMeshComponent.h"
-#include "Components/PrimitiveComponents/Physics/UBoxShapeComponent.h"
 #include "GameFramework//PlayerController.h"
 #include "GameFramework/Character.h"
 #include "Particles/ParticleSystemWorldManager.h"
 #include "Script/LuaManager.h"
 #include "UObject/UObjectArray.h"
 #include "UnrealEd/PrimitiveBatch.h"
+#include "Components/PrimitiveComponents/ParticleSystemComponent.h"
 
 void UWorld::InitWorld()
 {
+    FParticleSystemWorldManager::OnWorldInit(this);
+    
     // TODO: Load Scene
     if (Level == nullptr)
     {
@@ -44,8 +39,6 @@ void UWorld::InitWorld()
     {
         CreateBaseObject(WorldType);
     }
-
-    FParticleSystemWorldManager::OnWorldInit(this);
 }
 
 void UWorld::LoadLevel(const FString& LevelName)
@@ -70,6 +63,12 @@ void UWorld::CreateBaseObject(EWorldType::Type WorldType)
     if (LocalGizmo == nullptr && WorldType)
     {
         LocalGizmo = FObjectFactory::ConstructObject<UTransformGizmo>(this);
+
+        // TODO : 삭제해야 될 Test 코드
+        AActor* TestActor = SpawnActor<AActor>();
+        UParticleSystemComponent* TestComp = TestActor->AddComponent<UParticleSystemComponent>(EComponentOrigin::Runtime);
+        TestComp->Template = FObjectFactory::ConstructObject<UParticleSystem>(this);
+        TestComp->Activate();
     }
 }
 
@@ -109,7 +108,6 @@ void UWorld::Tick(ELevelTick tickType, float deltaSeconds)
 
         FGameManager::Get().Tick(deltaSeconds);
     }
-
     
     FParticleSystemWorldManager::Get(this)->Tick(deltaSeconds, tickType);
 }

--- a/Week11_1/Engine/Source/Runtime/Engine/Classes/GameFramework/Actor.h
+++ b/Week11_1/Engine/Source/Runtime/Engine/Classes/GameFramework/Actor.h
@@ -332,7 +332,8 @@ T* AActor::AddComponent(EComponentOrigin Origin)
     }
 
     // TODO: RegisterComponent() 생기면 제거
-    Component->InitializeComponent();
+    //Component->InitializeComponent();
+    Component->RegisterComponent();
     Component->ComponentOrigin = Origin;
 
     return Component;

--- a/Week11_1/Engine/Source/Runtime/Engine/Classes/Particles/ParticleSystem.cpp
+++ b/Week11_1/Engine/Source/Runtime/Engine/Classes/Particles/ParticleSystem.cpp
@@ -2,6 +2,29 @@
 
 #include "ParticleModule.h"
 
+UParticleSystem::UParticleSystem()
+    : Super()
+    , bAnyEmitterLoopsForever(false)
+    , bShouldManageSignificance(false)
+    , bIsImmortal(false)
+    , bWillBecomeZombie(false)
+{
+    ThumbnailDistance = 200.0;
+    ThumbnailWarmup = 1.0;
+
+    UpdateTime_FPS = 60.0f;
+    UpdateTime_Delta = 1.0f/60.0f;
+    WarmupTime = 0.0f;
+    WarmupTickRate = 0.0f;
+    
+    bAutoDeactivate = true;
+    MinTimeBetweenTicks = 0;
+    InsignificanceDelay = 0.0f;
+    MaxPoolSize = 32;
+
+    bAllowManagedTicking = true;
+}
+
 bool UParticleSystem::CanBePooled()const
 {
     if (MaxPoolSize == 0)

--- a/Week11_1/Engine/Source/Runtime/Engine/Classes/Particles/ParticleSystem.cpp
+++ b/Week11_1/Engine/Source/Runtime/Engine/Classes/Particles/ParticleSystem.cpp
@@ -1,0 +1,120 @@
+#include "ParticleSystem.h"
+
+#include "ParticleModule.h"
+
+bool UParticleSystem::CanBePooled()const
+{
+    if (MaxPoolSize == 0)
+    {
+        return false;
+    }
+
+    return true;
+}
+
+bool UParticleSystem::CalculateMaxActiveParticleCounts()
+{
+    const bool bSuccess = true;
+
+    for (int32 EmitterIndex = 0; EmitterIndex < Emitters.Num(); EmitterIndex++)
+    {
+        const UParticleEmitter* Emitter = Emitters[EmitterIndex];
+        if (Emitter)
+        {
+            // if (Emitter->CalculateMaxActiveParticleCount() == false)
+            // {
+            //     bSuccess = false;
+            // }
+        }
+    }
+
+    return bSuccess;
+}
+
+void UParticleSystem::SetDelay(const float InDelay)
+{
+    Delay = InDelay;
+}
+
+bool UParticleSystem::RemoveAllDuplicateModules(bool bInMarkForCooker, TMap<UObject*, bool>* OutRemovedModules)
+{
+    // 이 함수는 하나의 UParticleSystem 에셋을 스캔해서 같은 클래스에 속하고, 설정(프로퍼티)까지 완전히 동일한 파티클 모듈 인스턴스를 찾아내고, 중복된 모듈을 하나의 대표 모듈로 통합해 주는 작업을 합니다.
+    //
+    // 모듈 수집
+        // 모든 이터미터(Emitters)와 각 LOD 레벨의 SpawnModule 및 Modules[]를 훑으면서
+        // ClassToModulesMap 에 “클래스 → (모듈 인스턴스 → 개수)” 맵을 만듭니다.
+    // 중복 검사
+        // 같은 클래스 내에서 모듈들이 프로퍼티(Transient·EditorOnly·Cascade 카테고리 제외)까지 완벽히 동일한지 Property::Identical_InContainer 로 비교
+        // 완전히 일치하는 모듈간에는 한쪽을 “대표 모듈”로 삼고, 나머지를 ReplaceModuleMap 에 등록
+    // 중복 제거
+        // 실제로 LOD 레벨 리스트를 다시 돌며, ReplaceModuleMap 에 등록된 모듈들은 모두 대표 모듈 포인터로 치환(replace)
+        // bInMarkForCooker 가 켜져 있다면, 제거된 모듈을 RF_Transient 로 표시해 패키지 사이즈를 줄이도록 준비
+    // 후처리
+        // 에디터·쿠커 전용 옵션에 따라 필요하다면, 실제 리스트를 업데이트 (UpdateAllModuleLists)
+
+    return true;
+}
+
+void UParticleSystem::UpdateAllModuleLists()
+{
+    // for (int32 EmitterIdx = 0; EmitterIdx < Emitters.Num(); EmitterIdx++)
+    // {
+    //     UParticleEmitter* Emitter = Emitters[EmitterIdx];
+    //     if (Emitter != nullptr)
+    //     {
+    //         for (int32 LODIdx = 0; LODIdx < Emitter->LODLevels.Num(); LODIdx++)
+    //         {
+    //             UParticleLODLevel* LODLevel = Emitter->LODLevels[LODIdx];
+    //             if (LODLevel != nullptr)
+    //             {
+    //                 //LOD 레벨별 모듈 리스트 갱신  
+    //                 LODLevel->UpdateModuleLists();
+    //             }
+    //         }
+    //
+    //         // Allow type data module to cache any module info
+    //         if(Emitter->LODLevels.Num() > 0)
+    //         {
+    //             UParticleLODLevel* HighLODLevel = Emitter->LODLevels[0];
+    //             if (HighLODLevel != nullptr && HighLODLevel->TypeDataModule != nullptr)
+    //             {
+    //                 // Allow TypeData module to cache pointers to modules
+    //                 HighLODLevel->TypeDataModule->CacheModuleInfo(Emitter);
+    //             }
+    //         }
+    //
+    //         // Update any cached info from modules on the emitter
+    //         Emitter->CacheEmitterModuleInfo();
+    //     }
+    // }
+}
+
+void UParticleSystem::BuildEmitters()
+{
+    const int32 EmitterCount = Emitters.Num();
+    for ( int32 EmitterIndex = 0; EmitterIndex < EmitterCount; ++EmitterIndex )
+    {
+        if (UParticleEmitter* Emitter = Emitters[EmitterIndex])
+        {
+            //Emitter->Build();
+        }
+    }
+}
+
+bool UParticleSystem::ContainsEmitterType(UClass* TypeData)
+{
+    for ( int32 EmitterIndex = 0; EmitterIndex < Emitters.Num(); ++EmitterIndex)
+    {
+        UParticleEmitter* Emitter = Emitters[EmitterIndex];
+        if (Emitter)
+        {
+            // UParticleLODLevel* LODLevel = Emitter->LODLevels[0];
+            // if (LODLevel && LODLevel->TypeDataModule && LODLevel->TypeDataModule->IsA(TypeData))
+            // {
+            //     return true;
+            // }
+        }
+    }
+	
+    return false;
+}

--- a/Week11_1/Engine/Source/Runtime/Engine/Classes/Particles/ParticleSystem.h
+++ b/Week11_1/Engine/Source/Runtime/Engine/Classes/Particles/ParticleSystem.h
@@ -129,6 +129,7 @@ public:
     /** 시스템이 불멸인지 여부 확인 (무한 루프 + 무제한 지속시간) */
     bool IsImmortal() const { return bIsImmortal; }
 
+    bool AllowManagedTicking()const { return bAllowManagedTicking; }
 private:
     /** 중요도 관리를 해야 하는지 여부 */
     bool bShouldManageSignificance;

--- a/Week11_1/Engine/Source/Runtime/Engine/Classes/Particles/ParticleSystem.h
+++ b/Week11_1/Engine/Source/Runtime/Engine/Classes/Particles/ParticleSystem.h
@@ -2,9 +2,141 @@
 #include "Container/Array.h"
 #include "CoreUObject/UObject/Object.h"
 #include "ParticleEmitter.h"
+#include "UObject/ObjectMacros.h"
+
+class UParticleSystemComponent;
 
 class UParticleSystem : public UObject
 {
+    DECLARE_CLASS(UParticleSystem, UObject)
+    UParticleSystem();
+
+    uint32 MaxPoolSize;
+
+    /**
+     * 풀을 초기화하기 위해 미리 생성할 인스턴스 개수입니다.
+     * 이 값만큼 로드 시점에 인스턴스를 채워 두어 런타임 활성화 비용을 분산할 수 있습니다.
+     * 단, 레벨 로드 시점이 아닌 플레이 중 로드/언로드되는 시스템에 사용하면
+     * 큰 히치(프레임 끊김)가 발생할 수 있으니 주의해야 합니다.
+     */
+    uint32 PoolPrimeSize = 0;
+
+    
+    /** UpdateTime_FPS - FixedTime 모드에서 초당 프레임 수(FPS)로 업데이트합니다 */
+    float UpdateTime_FPS;
+
+    /** UpdateTime_Delta - 내부용 변수입니다 */
+    float UpdateTime_Delta;
+
+    /**
+     * WarmupTime - 파티클 시스템이 처음 렌더링될 때 예열할 시간입니다
+     * 경고: WarmupTime은 활성화 시 요청된 시간만큼 파티클 시스템을 시뮬레이션함으로써 구현됩니다.
+     * 특히 파티클 수가 많은 경우 버벅임(hitching)을 유발할 수 있으니 주의해서 사용하십시오.
+     */
+    float WarmupTime;
+
+    /** WarmupTickRate - 예열 중 틱(tick)마다의 시간 간격입니다.
+        값을 높이면 성능이 향상되고, 낮추면 정확도가 향상됩니다.
+        0으로 설정하면 기본 틱 시간(tick time)을 사용합니다. */
+    float WarmupTickRate;
+    
     TArray<UParticleEmitter*> Emitters;
+
+    /** Cascade에서 파티클 시스템을 미리보기 위해 사용하는 컴포넌트 */
+    UParticleSystemComponent* PreviewComponent;
+
+    /** 썸네일 이미지를 렌더링할 때 시스템을 배치할 거리 */
+    float ThumbnailDistance;
+
+    /** 썸네일 이미지를 위해 시스템을 예열할 시간 */
+    float ThumbnailWarmup;
+
+    /** ActivateSystem 호출 시 파티클 시스템이 지연될 시간 */
+    float Delay;
+
+    /** 지연 시간을 범위로 사용할 경우 지연 시간의 하한값 */
+    float DelayLow;
+
+    /** true이면, 시스템의 Z축이 카메라를 향하도록 정렬됨 */
+    bool bOrientZAxisTowardCamera;
+
+    /** 에디터 전용: Cascade에서 피크 활성 파티클 수를 초기화하길 원하는 경우 표시 */
+    bool bShouldResetPeakCounts;
+
+    /** 로드 시 설정됨. 해당 시스템이 물리를 사용하는지 여부 표시 */
+    bool bHasPhysics;
+
+    /**
+     * true이면, 지연 시간을 [DelayLow..Delay] 범위에서 선택함
+     */
+    bool bUseDelayRange;
+
+    /** 관리형 틱(Manged Ticking)을 허용할지 여부 */
+    bool bAllowManagedTicking;
+
+    /** 자동 비활성화 여부 */
+    bool bAutoDeactivate;
+
+private:
+    /** 루프를 영원히 반복하는 이미터가 있는지 여부 */
+    bool bAnyEmitterLoopsForever;
+
+public:
+    /** 두 틱 사이의 최소 시간 */
+    uint32 MinTimeBetweenTicks;
+
+    /** 모든 이미터가 중요하지 않게 된 후, 시스템이 반응하기까지의 지연 시간 */
+    float InsignificanceDelay;
+
+    /** 풀링 가능 여부 반환 */
+    bool CanBePooled() const;
+
+    /** 활성 파티클 최대 수 계산 */
+    virtual bool CalculateMaxActiveParticleCounts();
+
+    /**
+     * 파티클 시스템의 스폰을 지연시킬 시간을 설정함
+     */
+    void SetDelay(float InDelay);
+
+    /**
+     * 중복된 모듈을 모두 제거함
+     *
+     * @param bInMarkForCooker true이면 제거된 오브젝트를 요리 대상에서 제외함
+     * @param OutRemovedModules 선택적으로 제거된 모듈을 담을 맵
+     *
+     * @return 성공 여부
+     */
+    bool RemoveAllDuplicateModules(bool bInMarkForCooker, TMap<UObject*,bool>* OutRemovedModules);
+
+    /** 모든 모듈 리스트를 갱신 */
+    void UpdateAllModuleLists();
+
+    /**
+     * 파티클 시스템의 모든 이미터를 빌드함
+     */
+    void BuildEmitters();
+
+    /**
+     * 이 시스템에 주어진 타입의 이미터가 포함되어 있는지 반환
+     * @param TypeData 확인할 이미터 타입 (UParticleModuleTypeDataBase의 자식 클래스여야 함)
+     */
+    bool ContainsEmitterType(UClass* TypeData);
+
+    /** 무한 루프하는 이미터가 있는지 확인 */
+    bool IsLooping() const { return bAnyEmitterLoopsForever; }
+
+    /** 시스템이 불멸인지 여부 확인 (무한 루프 + 무제한 지속시간) */
+    bool IsImmortal() const { return bIsImmortal; }
+
+private:
+    /** 중요도 관리를 해야 하는지 여부 */
+    bool bShouldManageSignificance;
+
+    /** 어떤 이미터도 무한 루프 + 무한 지속시간으로 인해 결코 사라지지 않는 경우 true */
+    bool bIsImmortal;
+
+    /** 어떤 이미터가 좀비 상태(무한 루프하면서도 일정 시점 이후 스폰을 멈추는 경우)가 되는지 여부 */
+    bool bWillBecomeZombie;
 
 };

--- a/Week11_1/Engine/Source/Runtime/Engine/Classes/Particles/ParticleSystemWorldManager.cpp
+++ b/Week11_1/Engine/Source/Runtime/Engine/Classes/Particles/ParticleSystemWorldManager.cpp
@@ -12,7 +12,7 @@ void FParticleSystemWorldManager::OnWorldInit(UWorld* World)
     WorldManagers.Add(World, NewWorldMan);
 }
 
-void FParticleSystemWorldManager::OnWorldCleanup(UWorld* World, bool bSessionEnded, bool bCleanupResources)
+void FParticleSystemWorldManager::OnWorldCleanup(UWorld* World)
 {
     if (FParticleSystemWorldManager** WorldMan = WorldManagers.Find(World))
     {

--- a/Week11_1/Engine/Source/Runtime/Engine/Classes/Particles/ParticleSystemWorldManager.cpp
+++ b/Week11_1/Engine/Source/Runtime/Engine/Classes/Particles/ParticleSystemWorldManager.cpp
@@ -6,45 +6,48 @@
 
 TMap<UWorld*, FParticleSystemWorldManager*> FParticleSystemWorldManager::WorldManagers = {};
 
-void FParticleSystemWorldManager::OnWorldInit(UWorld* World)
+int32 GbEnablePSCWorldManager = 1;
+
+void FParticleSystemWorldManager::OnWorldInit(UWorld* InWorld)
 {
-    FParticleSystemWorldManager* NewWorldMan = new FParticleSystemWorldManager(World);
-    WorldManagers.Add(World, NewWorldMan);
+    FParticleSystemWorldManager* NewWorldMan = new FParticleSystemWorldManager(InWorld);
+    WorldManagers.Add(InWorld, NewWorldMan);
 }
 
-void FParticleSystemWorldManager::OnWorldCleanup(UWorld* World)
+void FParticleSystemWorldManager::OnWorldCleanup(UWorld* InWorld)
 {
-    if (FParticleSystemWorldManager** WorldMan = WorldManagers.Find(World))
+    if (FParticleSystemWorldManager** WorldMan = WorldManagers.Find(InWorld))
     {
-        UE_LOG(LogLevel::Warning, TEXT("| OnWorldCleanup | WorldMan: %p | World: %p | %s |"), *WorldMan, World, GetData(World->GetName()));
+        UE_LOG(LogLevel::Warning, TEXT("| OnWorldCleanup | WorldMan: %p | World: %p | %s |"), *WorldMan, InWorld, GetData(InWorld->GetName()));
         delete (*WorldMan);
-        WorldManagers.Remove(World);
+        WorldManagers.Remove(InWorld);
     }
 }
 
-void FParticleSystemWorldManager::OnPreWorldFinishDestroy(UWorld* World)
+void FParticleSystemWorldManager::OnPreWorldFinishDestroy(UWorld* InWorld)
 {
-    if (FParticleSystemWorldManager** WorldMan = WorldManagers.Find(World))
+    if (FParticleSystemWorldManager** WorldMan = WorldManagers.Find(InWorld))
     {
-        UE_LOG(LogLevel::Warning, TEXT("| OnPreWorldFinishDestroy | WorldMan: %p | World: %p | %s |"), *WorldMan, World, GetData(World->GetName()));
+        UE_LOG(LogLevel::Warning, TEXT("| OnPreWorldFinishDestroy | WorldMan: %p | World: %p | %s |"), *WorldMan, InWorld, GetData(InWorld->GetName()));
         delete (*WorldMan);
-        WorldManagers.Remove(World);
+        WorldManagers.Remove(InWorld);
     }
 }
 
-void FParticleSystemWorldManager::OnWorldBeginTearDown(UWorld* World)
+void FParticleSystemWorldManager::OnWorldBeginTearDown(UWorld* InWorld)
 {
-    if (FParticleSystemWorldManager** WorldMan = WorldManagers.Find(World))
+    if (FParticleSystemWorldManager** WorldMan = WorldManagers.Find(InWorld))
     {
-        UE_LOG(LogLevel::Warning, TEXT("| OnWorldBeginTearDown | WorldMan: %p | World: %p | %s |"), *WorldMan, World, GetData(World->GetName()));
+        UE_LOG(LogLevel::Warning, TEXT("| OnWorldBeginTearDown | WorldMan: %p | World: %p | %s |"), *WorldMan, InWorld, GetData(InWorld->GetName()));
         delete (*WorldMan);
-        WorldManagers.Remove(World);
+        WorldManagers.Remove(InWorld);
     }
 }
 
 FParticleSystemWorldManager::FParticleSystemWorldManager(UWorld* InWorld)
 {
     bCachedParticleWorldManagerEnabled = GbEnablePSCWorldManager;
+    World = InWorld;
 }
 
 FParticleSystemWorldManager::~FParticleSystemWorldManager()

--- a/Week11_1/Engine/Source/Runtime/Engine/Classes/Particles/ParticleSystemWorldManager.h
+++ b/Week11_1/Engine/Source/Runtime/Engine/Classes/Particles/ParticleSystemWorldManager.h
@@ -13,11 +13,12 @@ class FParticleSystemWorldManager
 private:
     static TMap<UWorld*, FParticleSystemWorldManager*> WorldManagers;
     
+public: 
     static void OnWorldInit(UWorld* World);
-    static void OnWorldCleanup(UWorld* World, bool bSessionEnded, bool bCleanupResources);
+    static void OnWorldCleanup(UWorld* World);
     static void OnPreWorldFinishDestroy(UWorld* World);
     static void OnWorldBeginTearDown(UWorld* World);
-public:
+
     FORCEINLINE static FParticleSystemWorldManager* Get(UWorld* World)
     {
         FParticleSystemWorldManager** Ret =  WorldManagers.Find(World);

--- a/Week11_1/Engine/Source/Runtime/Engine/Classes/Particles/ParticleSystemWorldManager.h
+++ b/Week11_1/Engine/Source/Runtime/Engine/Classes/Particles/ParticleSystemWorldManager.h
@@ -30,6 +30,8 @@ public:
     }
 public:
     FParticleSystemWorldManager(UWorld* InWorld);
+    ~FParticleSystemWorldManager();
+    void Cleanup();
 
     bool RegisterComponent(UParticleSystemComponent* PSC);
     void UnregisterComponent(UParticleSystemComponent* PSC);

--- a/Week11_1/Engine/Source/Runtime/Engine/Classes/Particles/ParticleSystemWorldManager.h
+++ b/Week11_1/Engine/Source/Runtime/Engine/Classes/Particles/ParticleSystemWorldManager.h
@@ -14,10 +14,10 @@ private:
     static TMap<UWorld*, FParticleSystemWorldManager*> WorldManagers;
     
 public: 
-    static void OnWorldInit(UWorld* World);
-    static void OnWorldCleanup(UWorld* World);
+    static void OnWorldInit(UWorld* InWorld);
+    static void OnWorldCleanup(UWorld* InWorld);
     static void OnPreWorldFinishDestroy(UWorld* World);
-    static void OnWorldBeginTearDown(UWorld* World);
+    static void OnWorldBeginTearDown(UWorld* InWorld);
 
     FORCEINLINE static FParticleSystemWorldManager* Get(UWorld* World)
     {

--- a/Week11_1/Week11_1.vcxproj
+++ b/Week11_1/Week11_1.vcxproj
@@ -245,6 +245,7 @@ xcopy /y /d "$(ProjectDir)Engine\Source\ThirdParty\FBX_SDK\2020.3.7\lib\x64\$(Co
     <ClCompile Include="Engine\Source\Runtime\Engine\Classes\GameFramework\Pawn.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Engine\Classes\GameFramework\PlayerController.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Engine\Classes\GameFramework\PlayerInput.cpp" />
+    <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Particles\ParticleSystem.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Particles\ParticleSystemWorldManager.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Engine\Light\ShadowMapAtlas.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Engine\Light\ShadowResource.cpp" />


### PR DESCRIPTION
# PR: 파티클 시스템 컴포넌트 및 에셋 관리 기능 통합 개선

## 개요

본 PR은 두 가지 축의 변경 사항을 포함합니다.

1. **UParticleSystemComponent** 측 틱(batch tick) 관리 강화 및 생명주기 훅 추가
2. **UParticleSystem** 클래스를 통한 파티클 에셋 예열·모듈 관리 기능 구현

---

## 1. UParticleSystemComponent 개선

### 주요 변경점

* **틱 관리 판단 로직**

  ```cpp
  bool ShouldBeTickManaged() const;
  FORCEINLINE bool IsTickManaged() const {
      return ManagerHandle != INDEX_NONE && !IsPendingManagerRemove();
  }
  ```

  * `ShouldBeTickManaged()`에 `GbEnablePSCWorldManager`, `Template->AllowManagedTicking()`, 자식 없음 검사 추가
  * `IsTickManaged()`를 인라인 정의해 매니저 등록 상태를 간결히 확인

* **SetComponentTickEnabled**

  * 매니저 등록 상태에 따라 `Super::SetComponentTickEnabled()` 호출 혹은 월드 매니저 등록/해제 로직으로 틱 제어 분기

* **생명주기 훅**

  ```cpp
  virtual void OnRegister() override;
  virtual void OnUnregister() override;
  ```

  * `OnRegister()` 오버라이드: 이전 활성 상태(`bWasActive`)면 재활성화
  * `OnUnregister()` 오버라이드: 해제 시점에 틱 해제 및 파티클 리셋

* **틱 처리 분리 메서드**

  ```cpp
  void ComputeTickComponent_Concurrent();
  void FinalizeTickComponent();
  ```

  * `TickComponent` 내부 로직을 동시 처리 부분과 후처리 부분으로 분리

* **비트필드 멤버 추가**

  ```cpp
  // ManagerHandle:30, bPendingManagerAdd:1, bPendingManagerRemove:1
  int32 ManagerHandle           : 30;
  int32 bPendingManagerAdd      : 1;
  int32 bPendingManagerRemove   : 1;
  ```

---

## 2. UParticleSystem 클래스 신규 추가

### 파일

* `ParticleSystem.h`
* `ParticleSystem.cpp`

### 주요 기능

1. **예열(Warmup) 및 틱 주기 제어**

   * `float WarmupTime`, `float WarmupTickRate`
   * `float UpdateTime_FPS`, `float UpdateTime_Delta`

2. **에미터 관리**

   * `TArray<UParticleEmitter*> Emitters`
   * `void BuildEmitters();`
   * `bool ContainsEmitterType(UClass* TypeData);`

3. **모듈 중복 제거**

   * `bool RemoveAllDuplicateModules(bool bInMarkForCooker, TMap<UObject*,bool>* OutRemovedModules);`

4. **모듈 리스트 갱신**

   * `void UpdateAllModuleLists();`

5. **썸네일 & 지연 설정**

   * `float ThumbnailDistance`, `float ThumbnailWarmup`
   * `float Delay`, `float DelayLow`, `bool bUseDelayRange`

6. **관리형 틱 지원**

   * `bool bAllowManagedTicking`
   * `bool AllowManagedTicking() const;`

7. **추가 유틸리티**

   * `virtual bool CalculateMaxActiveParticleCounts();`
   * `void SetDelay(float InDelay);`

---

## 검증 시나리오 제안
1. **예열 동작**

   * `WarmupTime`, `WarmupTickRate` 설정에 따른 초기 시뮬레이션 동작 관찰

2. **모듈 중복 제거**

   * 동일 속성 모듈 배치 후 `RemoveAllDuplicateModules()` 결과 검증

3. **ContainsEmitterType**

   * 특정 모듈 타입 포함 여부에 따른 `true`/`false` 반환 확인

---

## 테스트 및 연동 흐름

`UWorld::CreateBaseObject()` 내부에 아래와 같이 작성 후, 파티클 컴포넌트 생성→활성화→월드 매니저 연동 및 틱 호출까지 확인할 수 있습니다.

```cpp
// 컴포넌트 생성 및 초기화
AActor* TestActor = SpawnActor<AActor>();
UParticleSystemComponent* TestComp = TestActor->AddComponent<UParticleSystemComponent>(EComponentOrigin::Runtime);
TestComp->Template = FObjectFactory::ConstructObject<UParticleSystem>(this);
TestComp->Activate();
```

1. `Activate()` 호출 시 `SetComponentTickEnabled(true)`가 실행되어
   `FParticleSystemWorldManager::RegisterComponent(UParticleSystemComponent* PSC)`가 호출됩니다.
2. 월드 틱(`World->Tick()`) 과정에서

   ```cpp
   FParticleSystemWorldManager::Get(this)->Tick(deltaSeconds, TickType);
   ```

   이 호출되어 내부 `PendingRegisterPSCs`를 매니저 리스트로 통합(AddPSC),
   이후 `ManagedPSCs` 리스트의 모든 컴포넌트에 대해 `TickComponent(DeltaTime)`를 실행합니다.